### PR TITLE
Add an option to disable response streaming

### DIFF
--- a/src/bespoken/__main__.py
+++ b/src/bespoken/__main__.py
@@ -133,7 +133,7 @@ def chat(
     tools: list = None,
     slash_commands: dict = None,
     history_callback: Optional[Callable] = None,
-    stream: bool = typer.Option(True, "--stream", "-s", help="Stream the response from the LLM", default=True),
+    stream: bool = typer.Option(True, "--stream", "-s", help="Stream the response from the LLM"),
 ):
     """Run the bespoken chat assistant."""
     # Set debug mode globally


### PR DESCRIPTION
For compatibility with some models (namely claude on bedrock with tool calling), I'd prefer an option to disable streaming. This has been tested locally.